### PR TITLE
add a service account to cloud run workflow

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -56,4 +56,5 @@ jobs:
           project_id: ${{ inputs.gcp-project }}
           env_vars: ${{ inputs.env-vars }}
           service: ${{ inputs.app-name }}
+          service_account: ${{ inputs.service-account }}
           image: ${{ inputs.artifact-registry }}:${{ inputs.tag }}


### PR DESCRIPTION
this updates the cloud run workflow to use the input service account rather than the default compute account