### PR TITLE
Composite actions for building container and authenticating on GCP

### DIFF
--- a/.github/actions/auth-gcp-artifact-registry/action.yml
+++ b/.github/actions/auth-gcp-artifact-registry/action.yml
@@ -26,12 +26,17 @@ runs:
       uses: 'google-github-actions/setup-gcloud@v1'
 
     - name: Split location and app names
+      id: split
       env:
         REGISTRY: ${{ inputs.artifact-registry }}
       shell: bash
       run: |
-          echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
-          echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
+          location=${REGISTRY%%/*}
+          app_name=${REGISTRY##*/}
+          echo "location=$location"
+          echo "app_name=$app_name"
+          echo "location=$location" >> $GITHUB_OUTPUT
+          echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
     - name: 'Configure docker for gcloud auth'
       shell: bash

--- a/.github/actions/auth-gcp-artifact-registry/action.yml
+++ b/.github/actions/auth-gcp-artifact-registry/action.yml
@@ -1,0 +1,41 @@
+name: "Authenticate to GCP Artifact Registry using workload identity"
+description: "Authenticate to GCP Artifact Registry using workload identity"
+inputs:
+  workload-id-provider:
+    description: "Workload identity provider"
+    required: true
+  service-account:
+    description: "Service account to use"
+    required: true
+  artifact-registry:
+    description: "Artifact registry to push the image to"
+    required: true
+  
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - id: auth
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        workload_identity_provider: ${{ inputs.workload-id-provider }}
+        service_account: ${{ inputs.service-account }}
+        access_token_lifetime: '20m'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: Split location and app names
+      env:
+        REGISTRY: ${{ inputs.artifact-registry }}
+      shell: bash
+      run: |
+          echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
+          echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
+
+    - name: 'Configure docker for gcloud auth'
+      shell: bash
+      run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'

--- a/.github/actions/auth-gcp-artifact-registry/action.yml
+++ b/.github/actions/auth-gcp-artifact-registry/action.yml
@@ -14,9 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
     - id: auth
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v1'

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -12,11 +12,11 @@ inputs:
     description: "Dockerfile path"
     required: true
   push:
-    description: "Push the image to the remote repository"
+    description: "Push the image to the remote repository. Either push or load must be true"
     required: true
     default: 'true'
   load:
-    description: "Load the image in the local runner"
+    description: "Load the image in the local runner. Cannot be true if #platforms > 1"
     required: true
     default: 'false'
   registry:

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -1,0 +1,80 @@
+name: "Build docker image"
+description: "Build a docker image"
+inputs:
+  platforms:
+    description: "Image platform(s)"
+    required: true
+    default: linux/amd64
+  context:
+    description: "Dockerfile Build context path"
+    required: true
+  dockerfile:
+    description: "Dockerfile path"
+    required: true
+  push:
+    description: "Push the image to the remote repository"
+    required: true
+    default: 'true'
+  load:
+    description: "Load the image in the local runner"
+    required: true
+    default: 'false'
+  registry:
+    description: "Registry to push the image to"
+    required: true
+  tag:
+    description: "Image tag"
+    required: true
+    default: latest
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build container image
+      uses: docker/build-push-action@v4
+      with:
+        platforms: ${{ inputs.platforms }}
+        file: ${{ inputs.dockerfile }}
+        context: ${{ inputs.context }}
+        push: ${{ tojson(inputs.push) }}
+        tags: |
+          ${{ inputs.registry }}:${{ inputs.tag }}
+        load: ${{ tojson(inputs.load) }}
+        build-args: GETH_COMMIT={{ github.sha }}
+        cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
+        cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max
+        provenance: true
+
+    - uses: sigstore/cosign-installer@main
+
+    - name: Sign container image
+      env:
+        COSIGN_EXPERIMENTAL: "true"
+      shell: bash
+      run: |
+        cosign sign --yes ${{ inputs.artifact-registry }}@${{ steps.docker-build-push.outputs.digest }}
+
+    - name: Run Trivy vulnerability scanner
+      if: ${{ inputs.trivy == true }}
+      uses: aquasecurity/trivy-action@master
+      env:
+        REGISTRY: ${{ inputs.artifact-registry }}
+      with:
+        image-ref: "${{ inputs.registry }}:${{ inputs.tag }}"
+        timeout: 5m
+        vuln-type: "os,library"
+        severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+        format: "sarif"
+        output: "trivy-results.sarif"
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      if: ${{ inputs.trivy == true }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: "trivy-results.sarif"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -12,7 +12,8 @@ inputs:
     description: "Dockerfile path"
     required: true
   push:
-    description: "Push the image to the remote repository. Either push or load must be true"
+    description: "Push the image to the remote repository.
+      Requires to be pre-authenticated to the registry. Either push or load must be true"
     required: true
     default: 'true'
   load:
@@ -26,10 +27,6 @@ inputs:
     description: "Image tag"
     required: true
     default: latest
-  gcp-login:
-    description: "Authenticate to GCP Artifact Registry using workload identity"
-    required: true
-    default: 'false'
   workload-id-provider: 
     description: "Workload identity provider"
     required: false
@@ -40,33 +37,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - id: auth
-    #   name: 'Authenticate to Google Cloud'
-    #   uses: 'google-github-actions/auth@v1'
-    #   with:
-    #     workload_identity_provider: ${{ inputs.workload-id-provider }}
-    #     service_account: ${{ inputs.service-account }}
-    #     access_token_lifetime: '20m'
-
-    # - name: 'Set up Cloud SDK'
-    #   uses: 'google-github-actions/setup-gcloud@v1'
-
-    # - name: Split location and app names
-    #   id: split
-    #   env:
-    #     REGISTRY: ${{ inputs.registry }}
-    #   shell: bash
-    #   run: |
-    #       location=${REGISTRY%%/*}
-    #       app_name=${REGISTRY##*/}
-    #       echo "location=$location"
-    #       echo "app_name=$app_name"
-    #       echo "location=$location" >> $GITHUB_OUTPUT
-    #       echo "app_name=$app_name" >> $GITHUB_OUTPUT
-
-    # - name: 'Configure docker for gcloud auth'
-    #   shell: bash
-    #   run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -40,33 +40,33 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: auth
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
-      with:
-        workload_identity_provider: ${{ inputs.workload-id-provider }}
-        service_account: ${{ inputs.service-account }}
-        access_token_lifetime: '20m'
+    # - id: auth
+    #   name: 'Authenticate to Google Cloud'
+    #   uses: 'google-github-actions/auth@v1'
+    #   with:
+    #     workload_identity_provider: ${{ inputs.workload-id-provider }}
+    #     service_account: ${{ inputs.service-account }}
+    #     access_token_lifetime: '20m'
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v1'
+    # - name: 'Set up Cloud SDK'
+    #   uses: 'google-github-actions/setup-gcloud@v1'
 
-    - name: Split location and app names
-      id: split
-      env:
-        REGISTRY: ${{ inputs.registry }}
-      shell: bash
-      run: |
-          location=${REGISTRY%%/*}
-          app_name=${REGISTRY##*/}
-          echo "location=$location"
-          echo "app_name=$app_name"
-          echo "location=$location" >> $GITHUB_OUTPUT
-          echo "app_name=$app_name" >> $GITHUB_OUTPUT
+    # - name: Split location and app names
+    #   id: split
+    #   env:
+    #     REGISTRY: ${{ inputs.registry }}
+    #   shell: bash
+    #   run: |
+    #       location=${REGISTRY%%/*}
+    #       app_name=${REGISTRY##*/}
+    #       echo "location=$location"
+    #       echo "app_name=$app_name"
+    #       echo "location=$location" >> $GITHUB_OUTPUT
+    #       echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
-    - name: 'Configure docker for gcloud auth'
-      shell: bash
-      run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
+    # - name: 'Configure docker for gcloud auth'
+    #   shell: bash
+    #   run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -46,8 +46,8 @@ runs:
         tags: ${{ inputs.registry }}:${{ inputs.tag }}
         load: ${{ fromJSON(inputs.load) }}
         build-args: GETH_COMMIT={{ github.sha }}
-        cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
-        cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max
+        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
+        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
 
     - uses: sigstore/cosign-installer@main
@@ -57,13 +57,13 @@ runs:
         COSIGN_EXPERIMENTAL: "true"
       shell: bash
       run: |
-        cosign sign --yes ${{ inputs.artifact-registry }}@${{ steps.docker-build-push.outputs.digest }}
+        cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
       if: ${{ inputs.trivy == true }}
       uses: aquasecurity/trivy-action@master
       env:
-        REGISTRY: ${{ inputs.artifact-registry }}
+        REGISTRY: ${{ inputs.registry }}
       with:
         image-ref: "${{ inputs.registry }}:${{ inputs.tag }}"
         timeout: 5m

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -43,13 +43,12 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         push: ${{ tojson(inputs.push) }}
-        tags: |
-          ${{ inputs.registry }}:${{ inputs.tag }}
+        tags: ${{ inputs.registry }}:${{ inputs.tag }}
         load: ${{ tojson(inputs.load) }}
         build-args: GETH_COMMIT={{ github.sha }}
         cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
         cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max
-        provenance: true
+        provenance: ${{ tojson(true) }}
 
     - uses: sigstore/cosign-installer@main
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -57,6 +57,8 @@ runs:
         REGISTRY: ${{ inputs.registry }}
       shell: bash
       run: |
+          echo "location=${REGISTRY%%/*}"
+          echo "app_name=${REGISTRY##*/}"
           echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
           echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -40,15 +40,28 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-
-    - name: Login at GCP Artifact Registry
-      uses: ./.github/actions/auth-gcp-artifact-registry
-      if: inputs.gcp-login
+    - id: auth
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v1'
       with:
-        workload-id-provider: '${{ inputs.workload-id-provider }}'
-        service-account: '${{ inputs.service-account }}'
-        artifact-registry: '${{ inputs.registry }}'
+        workload_identity_provider: ${{ inputs.workload-id-provider }}
+        service_account: ${{ inputs.service-account }}
+        access_token_lifetime: '20m'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: Split location and app names
+      env:
+        REGISTRY: ${{ inputs.registry }}
+      shell: bash
+      run: |
+          echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
+          echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
+
+    - name: 'Configure docker for gcloud auth'
+      shell: bash
+      run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -26,10 +26,28 @@ inputs:
     description: "Image tag"
     required: true
     default: latest
+  gcp-login:
+    description: "Authenticate to GCP Artifact Registry using workload identity"
+    required: true
+    default: 'false'
+  workload-id-provider: 
+    description: "Workload identity provider"
+    required: false
+  service-account: 
+    description: "Service account to use"
+    required: false
 
 runs:
   using: "composite"
   steps:
+    - name: Login at GCP Artifact Registry
+      uses: ./.github/actions/auth-gcp-artifact-registry
+      if: ${{ inputs.gcp-login == true }}
+      with:
+        workload-id-provider: '${{ inputs.workload-id-provider }}'
+        service-account: '${{ inputs.service-account }}'
+        artifact-registry: '${{ inputs.registry }}'
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -57,10 +57,12 @@ runs:
         REGISTRY: ${{ inputs.registry }}
       shell: bash
       run: |
-          echo "location=${REGISTRY%%/*}"
-          echo "app_name=${REGISTRY##*/}"
-          echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
-          echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
+          location=${REGISTRY%%/*}
+          app_name=${REGISTRY##*/}
+          echo "location=$location"
+          echo "app_name=$app_name"
+          echo "location=$location" >> $GITHUB_OUTPUT
+          echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
     - name: 'Configure docker for gcloud auth'
       shell: bash

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -27,12 +27,6 @@ inputs:
     description: "Image tag"
     required: true
     default: latest
-  workload-id-provider: 
-    description: "Workload identity provider"
-    required: false
-  service-account: 
-    description: "Service account to use"
-    required: false
 
 runs:
   using: "composite"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Login at GCP Artifact Registry
       uses: ./.github/actions/auth-gcp-artifact-registry
-      if: ${{ inputs.gcp-login == true }}
+      if: inputs.gcp-login
       with:
         workload-id-provider: '${{ inputs.workload-id-provider }}'
         service-account: '${{ inputs.service-account }}'

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -44,7 +44,7 @@ runs:
         context: ${{ inputs.context }}
         push: ${{ fromJSON(inputs.push) }}
         tags: ${{ inputs.registry }}:${{ inputs.tag }}
-        load: ${{ fromJSON(true) }}
+        load: ${{ fromJSON(inputs.load) }}
         build-args: GETH_COMMIT={{ github.sha }}
         cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
         cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -63,6 +63,11 @@ runs:
       shell: bash
       run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -68,6 +68,8 @@ runs:
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
+      env:
+        REGISTRY: ${{ inputs.registry }}
       with:
         limit-access-to-actor: true
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -52,6 +52,7 @@ runs:
       uses: 'google-github-actions/setup-gcloud@v1'
 
     - name: Split location and app names
+      id: split
       env:
         REGISTRY: ${{ inputs.registry }}
       shell: bash

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -83,6 +83,7 @@ runs:
 
     - name: Build container image
       uses: docker/build-push-action@v4
+      id: docker-build-push
       with:
         platforms: ${{ inputs.platforms }}
         file: ${{ inputs.dockerfile }}

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -42,13 +42,13 @@ runs:
         platforms: ${{ inputs.platforms }}
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
-        push: ${{ tojson(inputs.push) }}
+        push: ${{ fromJSON(inputs.push) }}
         tags: ${{ inputs.registry }}:${{ inputs.tag }}
-        load: ${{ tojson(inputs.load) }}
+        load: ${{ fromJSON(true) }}
         build-args: GETH_COMMIT={{ github.sha }}
         cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
         cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max
-        provenance: ${{ tojson(true) }}
+        provenance: ${{ fromJSON(true) }}
 
     - uses: sigstore/cosign-installer@main
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -68,13 +68,6 @@ runs:
       shell: bash
       run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      env:
-        REGISTRY: ${{ inputs.registry }}
-      with:
-        limit-access-to-actor: true
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -40,6 +40,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v3
+
     - name: Login at GCP Artifact Registry
       uses: ./.github/actions/auth-gcp-artifact-registry
       if: inputs.gcp-login

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -15,6 +15,10 @@ on:
       tag:
         required: true
         type: string
+      platforms:
+        required: true
+        type: string
+        default: "linux/amd64"
       context:
         required: true
         type: string
@@ -32,111 +36,46 @@ on:
         required: false
         type: boolean
         default: true
-      vuln-type:
-        required: false
-        type: string
-        default: "os,library"
-      severity:
-        required: false
-        type: string
-        default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-      trivy-timeout: 
-        required: false
-        type: string
-        default: 5m
+      #vuln-type:
+      #  required: false
+      #  type: string
+      #  default: "os,library"
+      #severity:
+      #  required: false
+      #  type: string
+      #  default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      #trivy-timeout: 
+      #  required: false
+      #  type: string
+      #  default: 5m
 
 
 jobs:
-  Container-workflow:
+  auth-build-push-scan-container:
     runs-on: ubuntu-latest
-    permissions: # Must change the job token permissions to use JWT auth
+    permissions: # Required for workload identity auth and push the trivy results to GitHub
       contents: read
       id-token: write
       security-events: write
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-
-      - id: auth
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d'
-        with:
-          workload_identity_provider: ${{ inputs.workload-id-provider }}
-          service_account: ${{ inputs.service-account }}
-          access_token_lifetime: '20m'
-
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb'
-
-      - name: Split location and app  names
-        id: split
-        env:
-          REGISTRY: ${{ inputs.artifact-registry }}
-        run: |
-            echo "location=${REGISTRY%%/*}" >> $GITHUB_OUTPUT
-            echo "app_name=${REGISTRY##*/}" >> $GITHUB_OUTPUT
-
-      - name: 'Configure docker for gcloud auth'
-        run: 'gcloud auth configure-docker ${{ steps.split.outputs.location }}'
-
-      - name: Set sha variable
-        id: set-sha-var
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == 'pull_request' ]; then
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - id: docker-build-push
-        name: Build Docker image and push to Google Artifact Registry
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          platforms: linux/amd64
-          push: true
-          context: ${{ inputs.context }}
-          file: ${{ inputs.file }}
-          build-args: ${{ inputs.build-args }}
-          tags: |
-             ${{ inputs.artifact-registry }}:${{ inputs.tag }}
-             ${{ inputs.artifact-registry }}:${{ steps.set-sha-var.outputs.sha  }}
-          cache-from: type=registry,ref=${{ inputs.artifact-registry }}:buildcache
-          cache-to: type=registry,ref=${{ inputs.artifact-registry }}:buildcache,mode=max
-          provenance: ${{ inputs.provenance }}
+        uses: actions/checkout@v3
       
-      - uses: sigstore/cosign-installer@main
-      - name: Sign container image
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign --yes ${{ inputs.artifact-registry }}@${{ steps.docker-build-push.outputs.digest }}
-
-      - name: Run Trivy vulnerability scanner
-        #if: ${{ inputs.trivy == true }}
-        uses: aquasecurity/trivy-action@master
-        env:
-          REGISTRY: ${{ inputs.artifact-registry }}
+      - name: Authenticate to Google Cloud
+        uses: ./github/actions/auth-gcp-artifact-registry
         with:
-          image-ref: "${{ inputs.artifact-registry }}:${{ steps.set-sha-var.outputs.sha }}"
-          timeout: ${{ inputs.trivy-timeout }}
-          vuln-type: "${{ inputs.vuln-type }}"
-          severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-          format: "sarif"
-          output: "trivy-results.sarif"
+          workload-id-provider: ${{ inputs.workload-id-provider }}
+          service-account: ${{ inputs.service-account }}
+          artifact-registry: ${{ inputs.artifact-registry }}
 
-
-#      - name: Upload Trivy scan results to Onshore
-#        #if: ${{ inputs.trivy == true }}
-#        run: |
-#          curl -k -F 'trivy_logs=@trivy-results.json' https://66.251.224.39:8248
-#
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ inputs.trivy == true }}
-        uses: github/codeql-action/upload-sarif@v2
+      - name: Build, push and scan the container
+        uses: celo-org/reusable-workflows/.github/actions/build-container@jcortejoso/build-docker-composite-action
         with:
-          sarif_file: "trivy-results.sarif"
-
+          platforms: ${{ inputs.platforms }}
+          registry: ${{ inputs.artifact-registry }}
+          tag: ${{ inputs.tag }}
+          context: ${{ inputs.context }}
+          dockerfile: ${{ inputs.file }}
+          push: ${{ fromJSON(true) }}
+          load: ${{ fromJSON(false) }}
+          trivy: ${{ fromJSON(inputs.trivy) }}


### PR DESCRIPTION
Two new composite actions to:

- Authenticate on GCP Artifact Registry using GCP Workload Identity Provider with GitHub
- Build and push container images using docker buildx (multiplatform support)

For trivy scan, I made "mandatory" to scan for all kind of vulnerabilities (os, lib from any severity) and the scan timeout, as I think we will use the default values in all cases. Does this make sense to you, or someone prefer to propagate those parameters too?

Example of workflow using the two actions: https://github.com/celo-org/celo-blockchain/actions/runs/6315913589/workflow