### PR TITLE
Update composite action references

### DIFF
--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -75,14 +75,14 @@ jobs:
             echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud
-        uses: ./.github/actions/auth-gcp-artifact-registry
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@main
         with:
           workload-id-provider: ${{ inputs.workload-id-provider }}
           service-account: ${{ inputs.service-account }}
           docker-gcp-registries: ${{ steps.split.outputs.location }}
 
       - name: Build, push and scan the container
-        uses: ./.github/actions/build-container
+        uses: celo-org/reusable-workflows/.github/actions/build-container@main
         with:
           platforms: ${{ inputs.platforms }}
           registry: ${{ inputs.artifact-registry }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Build and publish npm package
-        uses: ./.github/actions/npm-publish
+        uses: celo-org/reusable-workflows/.github/actions/npm-publish@main
         with:
           node-version: ${{ inputs.node-version }}
           package-dir: ${{ inputs.package-dir }}


### PR DESCRIPTION
Building context is caller's context, so local references won't work. Need public references (or adding a checkout step with this repo as reference). : https://github.com/orgs/community/discussions/25289