### PR TITLE
Update container-cicd.yaml

### DIFF
--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -16,9 +16,8 @@ on:
         required: true
         type: string
       platforms:
-        required: true
         type: string
-        default: 'linux/amd64'
+        default: "linux/amd64"
       context:
         required: true
         type: string

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -18,7 +18,7 @@ on:
       platforms:
         required: true
         type: string
-        default: "linux/amd64"
+        default: 'linux/amd64'
       context:
         required: true
         type: string


### PR DESCRIPTION
`default` doesn't work with `required`. Make it explicit (would use `"linux/amd64"` if `platforms` is not specified).