### PR TITLE
Add support for multiple tags in action and workflow.

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -46,22 +46,41 @@ runs:
       id: process_tags
       shell: bash
       run: |
-        raw_tags="${{ inputs.tags }}"
+        function process_tags() {
+            local registry="${{ inputs.registry }}"
+            local raw_tags="${{ inputs.tags }}"
+            local processed_tags=()
 
-        processed_tags=()
+            # split tag field on comma character and add project + registry + image_name 
+            IFS=',' read -ra tags <<< "$raw_tags"
+            for tag in "${tags[@]}"; do
+                case "$tag" in 
+                *:*)
+                    # tag includes ':' - assume preprocessed and just pass to output
+                    processed_tags+=("$tag")
+                    ;;
+                *)
+                    # tag needs to include full host + repo definition
+                    processed_tags+=("$registry:$tag")
+                    ;;
+                esac
+            done
 
-        # split tag field on comma character and add project + registry + image_name 
-        IFS=',' read -ra tags <<< "$raw_tags"
-        for tag in "${tags[@]}"; do
-          processed_tags+=("${{ inputs.registry }}:$tag")
-        done
+            # format full tags into csv for docker/build-push-action
+            output_str=$(printf "%s," "${processed_tags[@]}")
 
-        # format full tags into csv for docker/build-push-action
-        output_str=$(printf "%s," "${processed_tags[@]}")
+            # export first processed tag in list for trivy scan
+            echo "first_tag=${processed_tags[0]}" >> $GITHUB_OUTPUT
+            echo "processed=$output_str" >> $GITHUB_OUTPUT
 
-        # export first processed tag in list for trivy scan
-        echo "first_tag=${processed_tags[0]}" >> $GITHUB_OUTPUT
-        echo "processed=$output_str" >> $GITHUB_OUTPUT
+            if [[ -n "$TRACE" ]]; then
+                echo "processed_tags=${processed_tags[@]}"
+                echo "output_str=$output_str"
+                echo "first_tag=${processed_tags[0]}"
+            fi
+        }
+
+        process_tags
 
     - name: Build container image
       uses: docker/build-push-action@v4

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -23,8 +23,8 @@ inputs:
   registry:
     description: "Registry to push the image to"
     required: true
-  tag:
-    description: "Image tag"
+  tags:
+    description: "CSV list of tags to apply to the image"
     required: true
     default: latest
   trivy:
@@ -42,6 +42,27 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
+    - name: Conditionally format tags with full image + repo definition
+      id: process_tags
+      shell: bash
+      run: |
+        raw_tags="${{ inputs.tags }}"
+
+        processed_tags=()
+
+        # split tag field on comma character and add project + registry + image_name 
+        IFS=',' read -ra tags <<< "$raw_tags"
+        for tag in "${tags[@]}"; do
+          processed_tags+=("${{ inputs.registry }}:$tag")
+        done
+
+        # format full tags into csv for docker/build-push-action
+        output_str=$(printf "%s," "${processed_tags[@]}")
+
+        # export first processed tag in list for trivy scan
+        echo "first_tag=${processed_tags[0]}" >> $GITHUB_OUTPUT
+        echo "processed=$output_str" >> $GITHUB_OUTPUT
+
     - name: Build container image
       uses: docker/build-push-action@v4
       id: docker-build-push
@@ -50,7 +71,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         push: ${{ fromJSON(inputs.push) }}
-        tags: ${{ inputs.registry }}:${{ inputs.tag }}
+        tags: ${{ steps.process_tags.outputs.processed }}
         load: ${{ fromJSON(inputs.load) }}
         build-args: GETH_COMMIT={{ github.sha }}
         cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
@@ -72,7 +93,7 @@ runs:
       env:
         REGISTRY: ${{ inputs.registry }}
       with:
-        image-ref: "${{ inputs.registry }}:${{ inputs.tag }}"
+        image-ref: "${{ steps.process_tags.outputs.first_tag }}"
         timeout: 15m
         vuln-type: "os,library"
         severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -12,7 +12,7 @@ on:
       artifact-registry:
         required: true
         type: string
-      tag:
+      tags:
         required: true
         type: string
       platforms:
@@ -72,7 +72,7 @@ jobs:
         with:
           platforms: ${{ inputs.platforms }}
           registry: ${{ inputs.artifact-registry }}
-          tag: ${{ inputs.tag }}
+          tags: ${{ inputs.tag }}
           context: ${{ inputs.context }}
           dockerfile: ${{ inputs.file }}
           push: ${{ fromJSON(true) }}


### PR DESCRIPTION
# Description

Adds support for multiple tags per image to implement https://github.com/celo-org/infrastructure/issues/1347 . This allows the upstream docker-build-action to apply distinct tags to the same image.

This changes the name of the parameter from `tag` to `tags` to reflect the usage of the var.

## Usage

* pass a CSV list of tags to be applied to the built image
    * include the full image repository and tag name (separated by `:`) to push to different repositories
> see [ci test repo](https://github.com/celo-org/ci-script-dev-repo/blob/main/.github/workflows/ci.yml#L24)

```
      - name: Build and push container
        #uses: celo-org/reusable-workflows/.github/actions/build-container@dhutch/multiple_tags
        uses: ./.github/actions/build-container/
        with:
          platforms: linux/amd64
          registry: us-west1-docker.pkg.dev/devopsre/ci-script-dev-repo/ci-script-dev-repo
          tags: new-tag,latest,v3,${{ github.sha }},us-west1-docker.pkg.dev/devopsre/ci-script-dev-repo/ci-script-dev-repo:tag_with_full_path
          context: .
          dockerfile: Dockerfile
          push: ${{ fromJSON(true) }}
          load: ${{ fromJSON(false) }}
          trivy: false

```

# Testing

* A version of this is tested at https://github.com/celo-org/ci-script-dev-repo where the action + workflow is able to work correctly
* https://github.com/celo-org/ci-script-dev-repo/actions/runs/6801787048/job/18493407412

<img width="1350" alt="image" src="https://github.com/celo-org/reusable-workflows/assets/85586/c086ec29-f1d7-4d48-a570-4ec2e560ed4a">
