### PR TITLE
Fix Trivy scan

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -107,7 +107,8 @@ runs:
         cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
-      if: ${{ fromJSON(inputs.trivy) == true }}
+      # if: ${{ fromJSON(inputs.trivy) == true }}
+      if: "true"
       uses: aquasecurity/trivy-action@master
       env:
         REGISTRY: ${{ inputs.registry }}
@@ -120,7 +121,8 @@ runs:
         output: "trivy-results.sarif"
 
     - name: Upload Trivy scan results to GitHub Security tab
-      if: ${{ fromJSON(inputs.trivy) == true }}
+      # if: ${{ fromJSON(inputs.trivy) == true }}
+      if: "true"
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: "trivy-results.sarif"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -107,8 +107,6 @@ runs:
         cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
-      # if: ${{ fromJSON(inputs.trivy) == true }}
-      if: "true"
       uses: aquasecurity/trivy-action@master
       env:
         REGISTRY: ${{ inputs.registry }}
@@ -121,8 +119,6 @@ runs:
         output: "trivy-results.sarif"
 
     - name: Upload Trivy scan results to GitHub Security tab
-      # if: ${{ fromJSON(inputs.trivy) == true }}
-      if: "true"
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: "trivy-results.sarif"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -107,7 +107,7 @@ runs:
         cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
-      if: ${{ inputs.trivy == true }}
+      if: ${{ fromJSON(inputs.trivy) == true }}
       uses: aquasecurity/trivy-action@master
       env:
         REGISTRY: ${{ inputs.registry }}
@@ -120,7 +120,7 @@ runs:
         output: "trivy-results.sarif"
 
     - name: Upload Trivy scan results to GitHub Security tab
-      if: ${{ inputs.trivy == true }}
+      if: ${{ fromJSON(inputs.trivy) == true }}
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: "trivy-results.sarif"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -108,6 +108,7 @@ runs:
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
+      if: ${{ inputs.trivy == 'true' }}
       env:
         REGISTRY: ${{ inputs.registry }}
       with:
@@ -119,6 +120,7 @@ runs:
         output: "trivy-results.sarif"
 
     - name: Upload Trivy scan results to GitHub Security tab
+      if: ${{ inputs.trivy == 'true' }}
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Fix trivy scan, as it was broken because [GitHub boolean inputs are not really booleans](https://github.com/actions/runner/issues/1483).