### PR TITLE
Allow custom gcp access-token-lifetime

### DIFF
--- a/.github/actions/auth-gcp-artifact-registry/action.yml
+++ b/.github/actions/auth-gcp-artifact-registry/action.yml
@@ -7,6 +7,10 @@ inputs:
   service-account:
     description: "Service account to use"
     required: true
+  access-token-lifetime:
+    description: "GCP token expiration timeout"
+    required: false
+    default: "20m"
   docker-gcp-registries:
     description: "GCP Artifact registry to login into. Check https://cloud.google.com/artifact-registry/docs/docker/authentication"
     required: true
@@ -21,7 +25,7 @@ runs:
       with:
         workload_identity_provider: ${{ inputs.workload-id-provider }}
         service_account: ${{ inputs.service-account }}
-        access_token_lifetime: '20m'
+        access_token_lifetime: ${{ inputs.access-token-lifetime }}
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'

--- a/.github/actions/auth-gcp-artifact-registry/action.yml
+++ b/.github/actions/auth-gcp-artifact-registry/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         workload_identity_provider: ${{ inputs.workload-id-provider }}
         service_account: ${{ inputs.service-account }}
-        access_token_lifetime: ${{ inputs.access-token-lifetime }}
+        access_token_lifetime: '${{ inputs.access-token-lifetime }}'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -9,6 +9,11 @@ on:
       service-account:
         required: true
         type: string
+      access-token-lifetime:
+        description: "GCP token expiration timeout"
+        required: false
+        type: string
+        default: "20m" 
       artifact-registry:
         required: true
         type: string
@@ -65,6 +70,7 @@ jobs:
         with:
           workload-id-provider: ${{ inputs.workload-id-provider }}
           service-account: ${{ inputs.service-account }}
+          access-token-lifetime: ${{ inputs.access-token-lifetime }}
           docker-gcp-registries: ${{ steps.split.outputs.location }}
 
       - name: Build, push and scan the container


### PR DESCRIPTION
Some workflows require more than 20 minutes for the workflow execution. Best is to be able to customize the token timeout.