### PR TITLE
Don't run in `container` tf wf

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -37,9 +37,6 @@ on:
 jobs:
   terraform:
     runs-on: ['self-hosted', 'org', 'terraform']
-    container:
-      image: us-west1-docker.pkg.dev/devopsre/actions-runner-controller/generic:latest
-      options: --user 0
     defaults:
       run:
         working-directory: ${{ inputs.working-dir }}


### PR DESCRIPTION
We can skip the `job.container` field in terraform workflow as required dependencies are already present in the runner image