### PR TITLE
Include docker build-args and attestations to image

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "Load the image in the local runner. Cannot be true if #platforms > 1"
     required: true
     default: 'false'
+  build-args:
+    description: "List of build-time variables"
+    required: false
   registry:
     description: "Registry to push the image to"
     required: true
@@ -92,9 +95,10 @@ runs:
         push: ${{ fromJSON(inputs.push) }}
         tags: ${{ steps.process_tags.outputs.processed }}
         load: ${{ fromJSON(inputs.load) }}
-        build-args: GETH_COMMIT={{ github.sha }}
+        build-args: ${{ inputs.build-args }}
         cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
         cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
+        attests: type=sbom,generator=image
         provenance: ${{ fromJSON(true) }}
 
     - uses: sigstore/cosign-installer@main

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -81,6 +81,7 @@ jobs:
           tags: ${{ inputs.tags }}
           context: ${{ inputs.context }}
           dockerfile: ${{ inputs.file }}
+          build-args: ${{ inputs.build-args }}
           push: ${{ fromJSON(true) }}
           load: ${{ fromJSON(false) }}
           trivy: ${{ fromJSON(inputs.trivy) }}


### PR DESCRIPTION
- Include the possibility of specifying build arguments.
- Include the two existing attestations to the container (https://docs.docker.com/build/attestations/)