### PR TITLE
Remove attests option

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -98,7 +98,6 @@ runs:
         build-args: ${{ inputs.build-args }}
         cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
         cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
-        attests: type=sbom,generator=image
         provenance: ${{ fromJSON(true) }}
 
     - uses: sigstore/cosign-installer@main


### PR DESCRIPTION
Attestations seems to be causing errors:

```
[+] Building 1.1s (3/3) FINISHED                                                                                                                                                                                        docker-container:optimistic_zhukovsky
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.42kB                                                                                                                                                                                                                   0.0s
 => ERROR resolve image config for docker.io/library/image:latest                                                                                                                                                                                        1.1s
 => [auth] library/image:pull token for registry-1.docker.io                                                                                                                                                                                             0.0s
------
 > resolve image config for docker.io/library/image:latest:
------
ERROR: failed to solve: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```