### PR TITLE
use github workflow commands for display/debug for readability

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -75,11 +75,10 @@ runs:
             echo "first_tag=${processed_tags[0]}" >> $GITHUB_OUTPUT
             echo "processed=$output_str" >> $GITHUB_OUTPUT
 
-            if [[ -n "$TRACE" ]]; then
-                echo "processed_tags=${processed_tags[@]}"
-                echo "output_str=$output_str"
-                echo "first_tag=${processed_tags[0]}"
-            fi
+            # add debugging
+            echo "::debug::processed_tags=${processed_tags[@]}"
+            echo "::debug::output_str=$output_str"
+            echo "::debug::first_tag=${processed_tags[0]}"
         }
 
         process_tags
@@ -100,14 +99,14 @@ runs:
     - name: Test
       shell: bash
       run: |
-        echo "Scanning for oidc credentials"
+        echo "::notice::Scanning for oidc credentials"
         set +e
         docker create --name="tmp_container" ${{ steps.docker-build.outputs.imageid }}
         found=$(docker export tmp_container | tar tf - | grep -e "gha-creds-.*.json" | wc -l)
         if [ $found -ge 1 ]; then
-            echo "Found oidc credentials"
-            echo "Add the following line to your .dockerignore file"
-            echo "gha-creds-*.json"
+            echo "::error::Found oidc credentials"
+            echo "::notice::Add the following line to your .dockerignore file"
+            echo "::notice::gha-creds-*.json"
         fi
         exit "$found"
 


### PR DESCRIPTION
This moves the user logging to use the github workflow commands here: 
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions

This will improve readability.

Also changed the check for a $TRACE variable to use the debug command to print only if the ACTIONS_STEP_DEBUG secret or variable is set
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging