### PR TITLE
feat: expose 'runs-on' to container-cicd workflow

### DIFF
--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -40,10 +40,15 @@ on:
         required: false
         type: boolean
         default: true
+      runner:
+        description: "runner label(s) - (JSON formatted list)"
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
 
 jobs:
   auth-build-push-scan-container:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     permissions: # Required for workload identity auth and push the trivy results to GitHub
       contents: read
       id-token: write


### PR DESCRIPTION
Since we now run a lot of workflows in our self-hosted runners, there is a need to expose the `runs-on` option to the container-cicd workflow. The default is left at "ubuntu-latest" to avoid any compatibility issues, but it could 
be overwritten with e.g. `'["self-hosted", "org", "8-cpu"]'`.