### PR TITLE
feat!: use docker/metadata-action to generate container labels/tags

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -66,6 +66,18 @@ runs:
           type=sha
           ${{ inputs.force-extra-tag != '' && format('type=raw,value={0}', inputs.force-extra-tag) || '' }}
 
+    - name: Set output tags
+      id: tags
+      shell: bash
+      run: |
+        set -euo pipefail
+        # that's the tag with the highest priority in metadata-action
+        first_tag="$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)"
+        # extract the repo base (everything before the last colon)
+        repo_base="${first_tag%:*}"
+        echo "repo-base=${repo_base}" >> "$GITHUB_OUTPUT"
+        echo "main-tag=${first_tag}" >> "$GITHUB_OUTPUT"
+
     - name: Build container image
       uses: docker/build-push-action@v6
       id: docker-build
@@ -73,7 +85,7 @@ runs:
         platforms: ${{ inputs.runner_platform }}
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
-        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.app-name }}:buildcache
+        cache-from: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache
         cache-to: type=local,dest=cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -107,9 +119,9 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}
         cache-from: type=local,src=cache
-        cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.app-name }}:buildcache,mode=max
+        cache-to: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
-
+    
     - uses: sigstore/cosign-installer@main
 
     - name: Sign container image
@@ -117,15 +129,13 @@ runs:
         COSIGN_EXPERIMENTAL: "true"
       shell: bash
       run: |
-        cosign sign --yes ${{ inputs.registry }}/${{ inputs.app-name }}@${{ steps.docker-build-push.outputs.digest }}
+        cosign sign --yes ${{ steps.tags.outputs.repo-base }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       if: ${{ inputs.trivy == 'true' }}
-      env:
-        REGISTRY: ${{ inputs.registry }}/${{ inputs.app-name }}
       with:
-        image-ref: "${{ steps.meta.outputs.version }}"
+        image-ref: "${{ steps.tags.outputs.main-tag }}"
         timeout: 15m
         vuln-type: "os,library"
         severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -86,7 +86,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         cache-from: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache
-        cache-to: type=local,dest=cache,mode=max
+        cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         load: true
@@ -118,7 +118,7 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}
-        cache-from: type=local,src=cache
+        cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -18,7 +18,7 @@ inputs:
   push:
     description: "Push the image to the remote repository. Requires to be pre-authenticated to the registry."
     required: true
-    default: 'true'
+    default: "true"
   build-args:
     description: "List of build-time variables"
     required: false
@@ -29,7 +29,7 @@ inputs:
     description: "sets the registry subfolder like {registry}/{app-name}:{tag}"
     required: true
   force-extra-tag:
-    description: > 
+    description: >
       Sets one specific tag in addition to the automatically inferred 
       'release', 'edge', 'latest' and 'sha' tags
     required: false
@@ -37,26 +37,26 @@ inputs:
   trivy:
     description: "Run trivy scan"
     required: true
-    default: 'true'
+    default: "true"
 
 runs:
   using: "composite"
   steps:
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    #TODO: strip the last / from the registry
     - name: Docker metadata
-      id: meta 
+      id: meta
       uses: docker/metadata-action@v5
       with:
         images: ${{inputs.registry}}/${{ inputs.app-name }}
         # see https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
-        # for reference. 
-        # "edge" is the latest on the default branch 
+        # for reference.
+        # "edge" is the latest on the default branch
         #   - this is mirrored with the "latest" tag for backwards compatibility
         #  An additional tag can be forced with inputs.force-extra-tag by the user.
         tags: |
@@ -121,7 +121,7 @@ runs:
         cache-from: type=local,src=cache
         cache-to: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
-    
+
     - uses: sigstore/cosign-installer@main
 
     - name: Sign container image

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "Dockerfile path"
     required: true
   push:
-    description: "Push the image to the remote repository. Requires to be pre-authenticated to the registry. Either push or load must be true"
+    description: "Push the image to the remote repository. Requires to be pre-authenticated to the registry."
     required: true
     default: 'true'
   build-args:
@@ -25,10 +25,15 @@ inputs:
   registry:
     description: "Registry to push the image to"
     required: true
-  tags:
-    description: "CSV list of tags to apply to the image"
+  app-name:
+    description: "sets the registry subfolder like {registry}/{app-name}:{tag}"
     required: true
-    default: latest
+  force-extra-tag:
+    description: > 
+      Sets one specific tag in addition to the automatically inferred 
+      'release', 'edge', 'latest' and 'sha' tags
+    required: false
+    default: ""
   trivy:
     description: "Run trivy scan"
     required: true
@@ -44,45 +49,22 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Conditionally format tags with full image + repo definition
-      id: process_tags
-      shell: bash
-      run: |
-        function process_tags() {
-            local registry="${{ inputs.registry }}"
-            local raw_tags="${{ inputs.tags }}"
-            local processed_tags=()
-
-            # split tag field on comma character and add project + registry + image_name 
-            IFS=',' read -ra tags <<< "$raw_tags"
-            for tag in "${tags[@]}"; do
-                case "$tag" in 
-                *:*)
-                    # tag includes ':' - assume preprocessed and just pass to output
-                    processed_tags+=("$tag")
-                    ;;
-                *)
-                    # tag needs to include full host + repo definition
-                    processed_tags+=("$registry:$tag")
-                    ;;
-                esac
-            done
-
-            # format full tags into csv for docker/build-push-action
-            output_str=$(printf "%s," "${processed_tags[@]}")
-
-            # export first processed tag in list for trivy scan
-            echo "first_tag=${processed_tags[0]}" >> $GITHUB_OUTPUT
-            echo "processed=$output_str" >> $GITHUB_OUTPUT
-
-            if [[ -n "$TRACE" ]]; then
-                echo "processed_tags=${processed_tags[@]}"
-                echo "output_str=$output_str"
-                echo "first_tag=${processed_tags[0]}"
-            fi
-        }
-
-        process_tags
+    - name: Docker metadata
+      id: meta 
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{inputs.registry}}/${{ inputs.app-name }}
+        # see https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
+        # for reference. 
+        # "edge" is the latest on the default branch 
+        #   - this is mirrored with the "latest" tag for backwards compatibility
+        #  An additional tag can be forced with inputs.force-extra-tag by the user.
+        tags: |
+          type=semver,pattern={{version}}
+          type=edge
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=sha
+          ${{ inputs.force-extra-tag != '' && format('type=raw,value={0}', inputs.force-extra-tag) || '' }}
 
     - name: Build container image
       uses: docker/build-push-action@v6
@@ -91,9 +73,10 @@ runs:
         platforms: ${{ inputs.runner_platform }}
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
-        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
+        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.app-name }}:buildcache
         cache-to: type=local,dest=cache
-        tags: ${{ steps.process_tags.outputs.processed }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         load: true
         build-args: ${{ inputs.build-args }}
 
@@ -120,10 +103,11 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         push: ${{ fromJSON(inputs.push) }}
-        tags: ${{ steps.process_tags.outputs.processed }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}
         cache-from: type=local,src=cache
-        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
+        cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.app-name }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
 
     - uses: sigstore/cosign-installer@main
@@ -133,15 +117,15 @@ runs:
         COSIGN_EXPERIMENTAL: "true"
       shell: bash
       run: |
-        cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
+        cosign sign --yes ${{ inputs.registry }}/${{ inputs.app-name }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       if: ${{ inputs.trivy == 'true' }}
       env:
-        REGISTRY: ${{ inputs.registry }}
+        REGISTRY: ${{ inputs.registry }}/${{ inputs.app-name }}
       with:
-        image-ref: "${{ steps.process_tags.outputs.first_tag }}"
+        image-ref: "${{ steps.meta.outputs.version }}"
         timeout: 15m
         vuln-type: "os,library"
         severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -146,4 +146,5 @@ runs:
       if: ${{ inputs.trivy == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
+        category: "${{ inputs.app-name }}"
         sarif_file: "trivy-results.sarif"

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -86,7 +86,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         cache-from: type=registry,ref=${{ steps.tags.outputs.repo-base }}:buildcache
-        cache-to: type=local,dest=cache
+        cache-to: type=local,dest=cache,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         load: true

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -14,10 +14,7 @@ on:
         required: false
         type: string
         default: "20m" 
-      artifact-registry:
-        required: true
-        type: string
-      tags:
+      registry:
         required: true
         type: string
       platforms:
@@ -32,6 +29,19 @@ on:
       build-args:
         required: false
         type: string
+      force-extra-tag:
+        description: > 
+          Sets one specific tag in addition to the automatically inferred 
+          'release', 'edge', 'latest' and 'sha' tags
+        required: false
+        default: ""
+      force-app-name:
+        description: > 
+          Sets the app name as a registry subfolder
+          {registry}/{app-name}:{tag}
+          If not set this will default to the repository name
+        required: false
+        default: ""
       provenance:
         required: false
         type: boolean
@@ -51,34 +61,21 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
-      
-      - name: Split location and app names
-        id: split
-        env:
-          REGISTRY: ${{ inputs.artifact-registry }}
-        shell: bash
-        run: |
-            location=${REGISTRY%%/*}
-            app_name=${REGISTRY##*/}
-            echo "location=$location"
-            echo "app_name=$app_name"
-            echo "location=$location" >> $GITHUB_OUTPUT
-            echo "app_name=$app_name" >> $GITHUB_OUTPUT
-
       - name: Authenticate to Google Cloud
         uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@main
         with:
           workload-id-provider: ${{ inputs.workload-id-provider }}
           service-account: ${{ inputs.service-account }}
           access-token-lifetime: ${{ inputs.access-token-lifetime }}
-          docker-gcp-registries: ${{ steps.split.outputs.location }}
+          docker-gcp-registries: ${{ inputs.registry}
 
       - name: Build, push and scan the container
         uses: celo-org/reusable-workflows/.github/actions/build-container@main
         with:
           platforms: ${{ inputs.platforms }}
-          registry: ${{ inputs.artifact-registry }}
-          tags: ${{ inputs.tags }}
+          registry: ${{ inputs.registry }}
+          app-name: ${{ inputs.registry || github.event.repository.name }}
+          force-extra-tag: ${{ inputs.force-extra-tag }}
           context: ${{ inputs.context }}
           dockerfile: ${{ inputs.file }}
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Dont merge yet - this is a draft PR and still WIP.

This has breaking changes and all github actions using this should first pin their git checkout to the current version
before this can get merged. It seems that most actions use the `@v2.0` tag though.