### PR TITLE
Fix docker cache invalidation due to relative cache dir

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -92,7 +92,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
-        cache-to: type=local,dest=cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
         tags: ${{ steps.process_tags.outputs.processed }}
         load: true
         build-args: ${{ inputs.build-args }}
@@ -122,7 +122,7 @@ runs:
         push: ${{ fromJSON(inputs.push) }}
         tags: ${{ steps.process_tags.outputs.processed }}
         build-args: ${{ inputs.build-args }}
-        cache-from: type=local,src=cache
+        cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
 

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -92,7 +92,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         context: ${{ inputs.context }}
         cache-from: type=registry,ref=${{ inputs.registry }}:buildcache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
         tags: ${{ steps.process_tags.outputs.processed }}
         load: true
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Whenever we had a dockerfile in a repo that used the reusable docker-build workflow and that had e.g. a dockerfile containing:

```dockerfile
COPY . .
RUN buildsomething
```
then this step was never cached in the second docker-build run from the docker build action.

This is due to the relative `dest=cache` cache-dir used in the first docker build, which exported the 
cache itself to the checked out root directory `<checkout-dir>/cache`. 

When the docker build context does contain the checkout root dir (which is most of the times the case), 
using `COPY . .` in the second run puts the cache itself into the docker-image, which not only clutters the image, but also 
invalidates the cache layer itself.

In addition to that, this uses `mode=max` for the local cache in order to have more cache-hits.

