### PR TITLE
Fix action and image references to version tag

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -126,7 +126,7 @@ runs:
         cache-to: type=registry,ref=${{ inputs.registry }}:buildcache,mode=max
         provenance: ${{ fromJSON(true) }}
 
-    - uses: sigstore/cosign-installer@main
+    - uses: sigstore/cosign-installer@v3
 
     - name: Sign container image
       env:
@@ -136,7 +136,7 @@ runs:
         cosign sign --yes ${{ inputs.registry }}@${{ steps.docker-build-push.outputs.digest }}
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.33.1
       if: ${{ inputs.trivy == 'true' }}
       env:
         REGISTRY: ${{ inputs.registry }}

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Akeyless Get Secrets
       id: get_auth_token
       uses:
-        docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
+        docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:sha256-26b7acdb3483678d2441a8744fb02184a85d5f275f07434dde8587d6b24944d6
       with:
         api-url: ${{ inputs.akeyless-api-gateway }}
         access-id: ${{ inputs.akeyless-github-access-id }}

--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   cloudrun-workflow:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: # Must change the job token permissions to use JWT auth
       contents: read
       id-token: write

--- a/.github/workflows/container-cicd-local.yaml
+++ b/.github/workflows/container-cicd-local.yaml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   Container-workflow:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: # Must change the job token permissions to use JWT auth
       contents: read
       id-token: write

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -66,7 +66,7 @@ jobs:
             echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud
-        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@main
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0.6
         with:
           workload-id-provider: ${{ inputs.workload-id-provider }}
           service-account: ${{ inputs.service-account }}
@@ -74,7 +74,7 @@ jobs:
           docker-gcp-registries: ${{ steps.split.outputs.location }}
 
       - name: Build, push and scan the container
-        uses: celo-org/reusable-workflows/.github/actions/build-container@main
+        uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0.6
         with:
           platforms: ${{ inputs.platforms }}
           registry: ${{ inputs.artifact-registry }}

--- a/.github/workflows/container-cicd.yaml
+++ b/.github/workflows/container-cicd.yaml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   auth-build-push-scan-container:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: # Required for workload identity auth and push the trivy results to GitHub
       contents: read
       id-token: write

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   go-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: # Must change the job token permissions to use JWT auth
       contents: read
       id-token: write

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Build and publish npm package
-        uses: celo-org/reusable-workflows/.github/actions/npm-publish@main
+        uses: celo-org/reusable-workflows/.github/actions/npm-publish@v2.0.6
         with:
           node-version: ${{ inputs.node-version }}
           package-dir: ${{ inputs.package-dir }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: tfsec
         if: ${{ github.event_name == 'pull_request' }}
-        uses: aquasecurity/tfsec-pr-commenter-action@main
+        uses: aquasecurity/tfsec-pr-commenter-action@v1
         with:
           github_token: ${{ github.token }}
           soft_fail_commenter: true

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -61,7 +61,7 @@ jobs:
       # it gets back after authenticating, which can be used for certain things (such as ansible)
       - name: Akeyless Get Secrets
         id: get_auth_token
-        uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
+        uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:sha256-26b7acdb3483678d2441a8744fb02184a85d5f275f07434dde8587d6b24944d6
         with:
           api-url: ${{ inputs.akeyless-api-gateway }}
           access-id: ${{ inputs.akeyless-github-access-id }}

--- a/.github/workflows/terraform2.yaml
+++ b/.github/workflows/terraform2.yaml
@@ -35,7 +35,7 @@ env:
 jobs:
   terraform:
     name: 'Terraform'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: # Must change the job token permissions to use JWT auth
       id-token: write
       contents: read


### PR DESCRIPTION
This moves the unfortunate `@main` version-references to their minor version tag for internal, clabs-org controlled action references, and to the major version tag for externally controlled action references.
Some image tag `:latest` references are also frozen to the currently most recent hash-based image tag.
The `ubuntu-latest` Github image is avoided and replaced with the latest ubuntu release.

**Important, please note: make sure that the `v2.0.6` tag is added and present on this commit after merging into `main`, because the references of the internal github-actions make use of this version tag, and a lot of repos are referencing to the `main` branch itself. If the tag is non-existent, it will break those CI workflows.**