### PR TITLE
fix: use correct attribute to infer major and minor tags

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,7 +22,8 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "if [ -z \"${nextRelease.prerelease}\" ]; then git tag -f v${nextRelease.major} && git tag -f v${nextRelease.major}.${nextRelease.minor} && git push origin --tags --force; else echo 'Skipping major/minor tags for prerelease'; fi"
+        "publishCmd": "./scripts/tag-versions.sh '${nextRelease.type}' '${nextRelease.version}'",
+        "shell": "/bin/bash"
       }
     ]
   ],

--- a/scripts/tag-versions.sh
+++ b/scripts/tag-versions.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+RELEASE_TYPE="$1"
+VERSION="$2"
+
+if [ "$RELEASE_TYPE" != "prerelease" ]; then
+    if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\. ]]; then
+        MAJOR=${BASH_REMATCH[1]}
+        MINOR=${BASH_REMATCH[2]}
+        
+        echo "Creating tags: v$MAJOR and v$MAJOR.$MINOR"
+        git tag -f "v$MAJOR"
+        git tag -f "v$MAJOR.$MINOR" 
+        git push origin --tags --force
+    else
+        echo "Error: Invalid version format: $VERSION"
+        exit 1
+    fi
+else
+    echo "Skipping major/minor tags for prerelease"
+fi


### PR DESCRIPTION
The `semantic-release/exec` `publishCmd` did not function properly.
Now it is deriving the major and minor version tags from the passed in version on a non-rc-release, 
and adding the tags `vX` and `vX.Y` tags to the commit at the workflow.