### PR TITLE
docker-build: normalize input-tags to CSV

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -196,7 +196,7 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build, push and scan the container
-        uses: celo-org/docker-build-composite-action@v1.0.1
+        uses: celo-org/docker-build-composite-action@v1.0.2
         id: docker-build-scan
         with:
           platforms: ${{ inputs.platforms }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -89,7 +89,6 @@ jobs:
     # Specify an environment here if using deployment environments
     environment:
       name: ${{ inputs.environment }}
-      url: "${{ inputs.environment != '' && format('https://{0}:{1}', inputs.artifact-registry, inputs.tags) || '' }}"
     permissions: # Required for workload identity auth and push the trivy results to GitHub
       actions: read
       contents: write

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Run Trivy Scan
         id: trivy-fs
         if: inputs.trivy-enabled
-        uses: celo-org/trivy-composite-action@v1.0.0
+        uses: celo-org/trivy-composite-action@v1.0.1
         with:
           scan-type: fs
           scan-ref: ${{ inputs.context }}
@@ -181,7 +181,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ inputs.workload-id-provider }}
           service_account: ${{ inputs.service-account }}
@@ -210,7 +210,7 @@ jobs:
       - name: Run Trivy Scan
         id: trivy-image
         if: inputs.trivy-enabled
-        uses: celo-org/trivy-composite-action@v1.0.0
+        uses: celo-org/trivy-composite-action@v1.0.1
         with:
           scan-type: image
           image-ref: ${{ steps.docker-build-scan.outputs.full-image-name }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -101,14 +101,23 @@ jobs:
       - name: Preprocess inputs
         id: preprocessed_inputs
         env:
+          RAW_TAGS: ${{ inputs.tags }}
           RAW_REGISTRY: ${{ inputs.artifact-registry }}
         run: |
           set -euo pipefail
 
           location=${RAW_REGISTRY%%/*}
           app_name=${RAW_REGISTRY##*/}
+          raw_tags="${RAW_TAGS//$'\r'/}"
+
+          normalized_tags="$(printf '%s' "$raw_tags" | tr ',' '\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')"
+          tags_csv="$(printf '%s' "$normalized_tags" | paste -sd, -)"
+
           echo "::debug::location=$location"
           echo "::debug::app_name=$app_name"
+          echo "::debug::tags=$tags_csv"
+
+          echo "tags_csv=$tags_csv" >> "$GITHUB_OUTPUT"
           echo "location=$location" >> $GITHUB_OUTPUT
           echo "app_name=$app_name" >> $GITHUB_OUTPUT
 
@@ -193,7 +202,7 @@ jobs:
         with:
           platforms: ${{ inputs.platforms }}
           registry: ${{ inputs.artifact-registry }}
-          tags: ${{ inputs.tags }}
+          tags: ${{ steps.preprocessed_inputs.outputs.tags_csv }}
           context: ${{ inputs.context }}
           dockerfile: ${{ inputs.file }}
           build-args: ${{ inputs.build-args }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -98,6 +98,20 @@ jobs:
       attestations: write
       pull-requests: write
     steps:
+      - name: Preprocess inputs
+        id: preprocessed_inputs
+        env:
+          RAW_REGISTRY: ${{ inputs.artifact-registry }}
+        run: |
+          set -euo pipefail
+
+          location=${RAW_REGISTRY%%/*}
+          app_name=${RAW_REGISTRY##*/}
+          echo "::debug::location=$location"
+          echo "::debug::app_name=$app_name"
+          echo "location=$location" >> $GITHUB_OUTPUT
+          echo "app_name=$app_name" >> $GITHUB_OUTPUT
+
       # Security policy docker is configured in step security app
       # Policy can be seen here https://app.stepsecurity.io/github/celo-org/actions/policies/docker
       # disable-sudo is set to false if debug is true, because tmate requires root to work.
@@ -138,19 +152,6 @@ jobs:
             }
             return true;
 
-      # Split the artifact-registry to give us both the registry url and app/image name
-      - name: Split location and app names
-        id: split
-        env:
-          REGISTRY: ${{ inputs.artifact-registry }}
-        run: |
-            location=${REGISTRY%%/*}
-            app_name=${REGISTRY##*/}
-            echo "::debug::location=$location"
-            echo "::debug::app_name=$app_name"
-            echo "location=$location" >> $GITHUB_OUTPUT
-            echo "app_name=$app_name" >> $GITHUB_OUTPUT
-
       - name: Run Trivy Scan
         id: trivy-fs
         if: inputs.trivy-enabled
@@ -168,7 +169,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.trivy-fs.outputs.sarif-file }}
-          category: fs-${{ steps.split.outputs.app_name }}
+          category: fs-${{ steps.preprocessed_inputs.outputs.app_name }}
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -216,7 +217,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.trivy-image.outputs.sarif-file }}
-          category: image-${{ steps.split.outputs.app_name }}
+          category: image-${{ steps.preprocessed_inputs.outputs.app_name }}
 
       - name: Add Trivy FileSystem Report to Workflow Summary
         if: inputs.summary && (steps.trivy-fs.outputs.text-report != '' || steps.trivy-image.outputs.text-report )

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,6 @@
 ---
-name: 'Run Container Workflow'
-on: 
+name: "Run Container Workflow"
+on:
   workflow_call:
     inputs:
       workload-id-provider:
@@ -13,7 +13,7 @@ on:
         description: "GCP token expiration timeout"
         required: false
         type: string
-        default: "20m" 
+        default: "20m"
       artifact-registry:
         required: true
         type: string
@@ -49,7 +49,7 @@ on:
         type: number
         description: "Workflow timeout"
       environment:
-        default: ''
+        default: ""
         description: "Deployment environment in github"
         type: string
       debug-enabled:
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     defaults:
       run:
-        shell: bash 
+        shell: bash
     # Specify an environment here if using deployment environments
     environment:
       name: ${{ inputs.environment }}
@@ -137,12 +137,12 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
-        if: inputs.debug-enabled == true 
+        if: inputs.debug-enabled == true
         with:
           detached: true
           limit-access-to-actor: true
-    
-      - name: 'Checkout'
+
+      - name: "Checkout"
         uses: actions/checkout@v4
 
       - name: Check if GHAS is Enabled
@@ -166,7 +166,7 @@ jobs:
         uses: celo-org/trivy-composite-action@v1.0.0
         with:
           scan-type: fs
-          scan-ref:  ${{ inputs.context }}
+          scan-ref: ${{ inputs.context }}
           timeout: ${{ inputs.trivy-timeout }}
           vuln-type: ${{ inputs.trivy-vuln-type }}
           severity: ${{ inputs.trivy-severity }}
@@ -186,7 +186,7 @@ jobs:
           workload_identity_provider: ${{ inputs.workload-id-provider }}
           service_account: ${{ inputs.service-account }}
           access_token_lifetime: ${{ inputs.access-token-lifetime }}
-          token_format: access_token 
+          token_format: access_token
 
       - name: Login to GAR
         uses: docker/login-action@v3
@@ -213,7 +213,7 @@ jobs:
         uses: celo-org/trivy-composite-action@v1.0.0
         with:
           scan-type: image
-          image-ref:  ${{ steps.docker-build-scan.outputs.full-image-name }}
+          image-ref: ${{ steps.docker-build-scan.outputs.full-image-name }}
           timeout: ${{ inputs.trivy-timeout }}
           vuln-type: ${{ inputs.trivy-vuln-type }}
           severity: ${{ inputs.trivy-severity }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'NPM Publish Workflow'
+name: "NPM Publish Workflow"
 on:
   workflow_call:
     inputs:
@@ -14,7 +14,7 @@ on:
         type: number
         description: "Workflow timeout"
       environment:
-        default: ''
+        default: ""
         description: "Deployment environment in github"
         type: string
       environment-url:
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     defaults:
       run:
-        shell: bash 
+        shell: bash
     # Specify an environment here if using deployment environments
     environment:
       name: ${{ inputs.environment }}
@@ -101,12 +101,12 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48
-        if: inputs.debug-enabled == true 
+        if: inputs.debug-enabled == true
         with:
           detached: true
           limit-access-to-actor: true
-    
-      - name: 'Checkout'
+
+      - name: "Checkout"
         uses: actions/checkout@v4
 
       - name: Check if GHAS is Enabled
@@ -127,10 +127,10 @@ jobs:
       - name: Run Trivy Scan
         id: trivy-fs
         if: inputs.trivy-enabled
-        uses: celo-org/trivy-composite-action@v1.0.0
+        uses: celo-org/trivy-composite-action@v1.0.1
         with:
           scan-type: fs
-          scan-ref:  ${{ inputs.package-dir }}
+          scan-ref: ${{ inputs.package-dir }}
           timeout: ${{ inputs.trivy-timeout }}
           vuln-type: ${{ inputs.trivy-vuln-type }}
           severity: ${{ inputs.trivy-severity }}
@@ -188,21 +188,21 @@ jobs:
 
       # Setup Node JS with input from node version and set the registry url for github packages
       # DON'T USE registry-url due to https://github.com/changesets/action/issues/132
-      - name: 'Setup Node JS'
+      - name: "Setup Node JS"
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: 'enable corepack for yarn'
+      - name: "enable corepack for yarn"
         run: sudo corepack enable yarn
         shell: bash
 
       # must call twice because of chicken and egg problem with yarn and node
-      # DON'T USE registry-url due to https://github.com/changesets/action/issues/132     
+      # DON'T USE registry-url due to https://github.com/changesets/action/issues/132
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install Dependencies
         shell: bash
@@ -221,4 +221,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ env.NPM_TOKEN }}
-          NPM_PROVENANCE: "1" 
+          NPM_PROVENANCE: "1"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'Terraform plan and apply'
+name: "Terraform plan and apply"
 
 on:
   workflow_call:
@@ -37,11 +37,11 @@ on:
         type: number
         description: "Workflow timeout in minutes"
       environment:
-        default: ''
+        default: ""
         description: "Deployment environment in GitHub"
         type: string
       environment-url:
-        default: ''
+        default: ""
         description: "Deployment environment URL in Okta"
         type: string
       debug-enabled:
@@ -138,7 +138,7 @@ jobs:
           service_account: ${{ inputs.service-account }}
           token_format: ${{ inputs.token-format }}
           access_token_scopes: ${{ inputs.access-token-scopes }}
-          access_token_lifetime: '20m'
+          access_token_lifetime: "20m"
 
       - name: set terraform variables
         id: config-vars
@@ -166,7 +166,7 @@ jobs:
       - name: Run Trivy Scan
         id: trivy-fs
         if: inputs.trivy-enabled
-        uses: celo-org/trivy-composite-action@v1.0.0
+        uses: celo-org/trivy-composite-action@v1.0.1
         with:
           scan-type: fs
           scan-ref: ${{ inputs.working-dir }}
@@ -195,7 +195,7 @@ jobs:
         run: terraform init
 
       # Terraform Format Check
- 
+
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check
@@ -226,28 +226,28 @@ jobs:
           ORIGINAL_FILENAME: ${{ steps.config-vars.outputs.app-name }}-plan.txt
           FORMATTED_FILENAME: ${{ steps.config-vars.outputs.app-name }}-formatted-plan.txt
         run: |
-            cat > ${{ env.ORIGINAL_FILENAME }} <<'EOF'
-            ${{ steps.showplan.outputs.stdout }}
-            EOF
-            echo original-plan=${{ env.ORIGINAL_FILENAME }} >> $GITHUB_OUTPUT
+          cat > ${{ env.ORIGINAL_FILENAME }} <<'EOF'
+          ${{ steps.showplan.outputs.stdout }}
+          EOF
+          echo original-plan=${{ env.ORIGINAL_FILENAME }} >> $GITHUB_OUTPUT
 
-            # Removes the refreshing from the plan output and then moves the + and - all the way
-            # to the left of the pull request to trigger github's colors
-            sed -E 's/^([[:space:]]+)([-+])/\2\1/g' ${{ env.ORIGINAL_FILENAME }} > ${{ env.FORMATTED_FILENAME }}
+          # Removes the refreshing from the plan output and then moves the + and - all the way
+          # to the left of the pull request to trigger github's colors
+          sed -E 's/^([[:space:]]+)([-+])/\2\1/g' ${{ env.ORIGINAL_FILENAME }} > ${{ env.FORMATTED_FILENAME }}
 
-            PLAN=$(cat ${{ env.FORMATTED_FILENAME }})
-            check=${#PLAN}
-            # Delimiting plan size to avoid error "Argument list too long" when posting the plan
-            if [ "$check" -ge 65000 ];
-            then
-              PLAN='Terraform plan is too long to be posted in the PR comment. Please check the Action run to verify it'
-            fi
+          PLAN=$(cat ${{ env.FORMATTED_FILENAME }})
+          check=${#PLAN}
+          # Delimiting plan size to avoid error "Argument list too long" when posting the plan
+          if [ "$check" -ge 65000 ];
+          then
+            PLAN='Terraform plan is too long to be posted in the PR comment. Please check the Action run to verify it'
+          fi
+          echo "$PLAN"
+          {
+            echo "formatted-plan<<EOF"
             echo "$PLAN"
-            {
-              echo "formatted-plan<<EOF"
-              echo "$PLAN"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload Terraform Plan
         if: github.event_name == 'pull_request' && steps.plan.outputs.exitcode != '0'


### PR DESCRIPTION
### docker-build workflow changes
#### Normalize input-tags to CSV
The `tags` input previously was expected to receive a csv-formatted list string
in order to work e.g. in the downstream `docker-composite-action`, where the input was passed to.
Now, it normalizes newline as well as comma-separated lists to comma-separated lists 
before passing it along. This makes it compatible with receiving e.g. the `docker/metadata-action`'s `tags` output.

#### Remove environment-url

Whenever a list of tags were passed to the input, the environment-url
was invalid. Since the environment key is on a job-level, pre-computing
the correct url would require to run a prior job, which is not very
efficient.
Since the url is mainly used for generating a link after deployment,
this is not critical to remove. If a correct URL is required, this
should be done with the actual artifact URL coming from the
docker-composite-action, which can be set during the job by interacting
with the github-api. For now, this is not implemented.


### other changes
- bump docker-build-composite-action to 1.0.2
- bump trivy-composite-action to 1.0.1
- refactors and formatting