### PR TITLE
fix: Remove provenance configuration

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -182,5 +182,3 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: ${{ inputs.publish-command }}
           version: ${{ inputs.version-command }}
-        env:
-          NPM_PROVENANCE: "1"


### PR DESCRIPTION
Remove provenance because it should be configured in the publish command, not manually.