### PR TITLE
Set GITHUB_TOKEN and NPM_TOKEN in workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -182,3 +182,6 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: ${{ inputs.publish-command }}
           version: ${{ inputs.version-command }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
Add environment variables for GitHub and NPM tokens in npm-publish workflow for publishing changeset